### PR TITLE
Bump version to keep up to date with Hudson and Artifactory libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
                     <groupId>com.thoughtworks.xstream</groupId>
                     <artifactId>xstream</artifactId>
                 </exclusion>
+		<exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bump version to keep up to date with Hudson and Artifactory libs

We were seeing an index-out-bounds exception on maven3 freestyle builds.
